### PR TITLE
Added `inter` symbol in favor of `sect` deprecation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ cd typst-math
 To build the WebAssembly module, you need to install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
 ```bash
 cd typst-math-rust
-wasm-pack build
+wasm-pack build --target nodejs
 ```
 Then you can run the extension by opening the project in VS Code and pressing `F5` to start a debug session.
 

--- a/typst-math-rust/src/utils/symbols.rs
+++ b/typst-math-rust/src/utils/symbols.rs
@@ -445,6 +445,16 @@ pub const SYMBOLS: phf::Map<&str, Symbol> = symbols! {
         sq.big: '⨅',
         sq.double: '⩎',
     ]; Keyword,
+    inter: [
+        '∩',
+        and: '⩄',
+        big: '⋂',
+        dot: '⩀',
+        double: '⋒',
+        sq: '⊓',
+        sq.big: '⨅',
+        sq.double: '⩎',
+    ]; Keyword,
 
     // Calculus.
     infinity: '∞'; Default,


### PR DESCRIPTION
https://github.com/typst/typst/blob/1b2714e1a758d6ee0f9471fd1e49cb02f6d8cde4/docs/changelog/0.13.0.md?plain=1#L304