### PR TITLE
chore: prune vscode dist

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,5 @@
+.github/
+assets/fonts/
 .vscode/**
 .vscode-test/**
 out/**


### PR DESCRIPTION
Some files in the vscode dist are unnecessary or duplicated, including:

- assets/fonts/** (duplicated with dist/fonts and unused)
- .github/ (unused)

final size:

```
2.4M  typst-math-0.1.10.vsix
```