### PR TITLE
feat: trim quote for string (str_block)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typst-math",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typst-math",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "installfont": "^0.0.12",
         "typst-math-rust": "file:typst-math-rust/pkg"
@@ -4754,7 +4754,7 @@
     },
     "typst-math-rust/pkg": {
       "name": "typst-math-rust",
-      "version": "0.1.6"
+      "version": "0.1.10"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
             "comparison": "",
             "letter": "",
             "group": "",
-            "operator": ""
+            "operator": "",
+            "string": ""
           },
           "markdownDescription": "The colors used to render math symbols in typst.\nDefault colors are based on the Monokai theme. They can be in `#RRGGBB` or `rgb(r, g, b)` format.",
           "properties": {
@@ -58,6 +59,10 @@
             "operator": {
               "type": "string",
               "description": "The color used for operators in typst."
+            },
+            "string": {
+              "type": "string",
+              "description": "The color used for strings in typst."
             }
           },
           "additionalProperties": false
@@ -76,6 +81,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "If true, unnecessary delimiters like parentheses in `$x^(2 x y)$` will be hidden."
+        },
+        "typst-math.hideLeadingAndTrailingQuotes": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "If true, leading and trailing quotes for *string* will be hidden."
         },
         "typst-math.revealOffset": {
           "type": "number",

--- a/src/decorations/decorations.ts
+++ b/src/decorations/decorations.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { createDecorationType, strictIntersection } from './helpers';
 import { Logger } from '../logger';
-import { blacklistedSymbols, getColors, getRenderingMode, customSymbols, renderSpaces, renderSymbolsOutsideMath, revealOffset, hideUnnecessaryDelimiters, reloadConfiguration } from '../utils';
+import { blacklistedSymbols, getColors, getRenderingMode, customSymbols, renderSpaces, renderSymbolsOutsideMath, revealOffset, hideUnnecessaryDelimiters, hideLeadingAndTrailingQuotes, reloadConfiguration } from '../utils';
 import getWASM from '../wasmHelper';
 import { updateStatusBarItem } from '../statusbar';
 import { CustomSymbol } from 'typst-math-rust';
@@ -34,6 +34,7 @@ export class Decorations {
     renderOutsideMath = renderSymbolsOutsideMath();
     renderSpaces = renderSpaces();
     hideUnnecessaryDelimiters = hideUnnecessaryDelimiters();
+    hideLeadingAndTrailingQuotes = hideLeadingAndTrailingQuotes();
     blacklistedSymbols = blacklistedSymbols();
     reveal_offset = revealOffset();
     customSymbols: CustomSymbol[] = [];
@@ -107,6 +108,7 @@ export class Decorations {
             this.renderOutsideMath = renderSymbolsOutsideMath();
             this.renderSpaces = renderSpaces();
             this.hideUnnecessaryDelimiters = hideUnnecessaryDelimiters();
+            this.hideLeadingAndTrailingQuotes = hideLeadingAndTrailingQuotes();
             this.blacklistedSymbols = blacklistedSymbols();
             this.reveal_offset = revealOffset();
             this.clearDecorations();
@@ -123,7 +125,7 @@ export class Decorations {
 
             let start = this.edition_state.edited_range?.start.line === undefined ? -1 : this.edition_state.edited_range?.start.line;
             let end = this.edition_state.edited_range?.end.line === undefined ? -1 : this.edition_state.edited_range?.end.line;
-            let parsed = getWASM().parse_document(this.activeEditor.document.getText() as string, start, end, this.renderingMode, this.renderOutsideMath, this.renderSpaces, this.hideUnnecessaryDelimiters, this.blacklistedSymbols, this.customSymbols);
+            let parsed = getWASM().parse_document(this.activeEditor.document.getText() as string, start, end, this.renderingMode, this.renderOutsideMath, this.renderSpaces, this.hideUnnecessaryDelimiters, this.hideLeadingAndTrailingQuotes, this.blacklistedSymbols, this.customSymbols);
 
             // If edited lines aren't defined, we clear all ranges
             // If they are defined, remove symbols whiwh were rendered again, and trnaslate ones after the edition

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,7 @@ function enumToColorName(colorEnum: Color): keyof Colors {
         case getWASM().Color.Letter: return "letter";
         case getWASM().Color.Set: return "group";
         case getWASM().Color.Number: return "number";
-        case getWASM().Color.String: return "letter";
+        case getWASM().Color.String: return "string";
     }
 }
 // Get colors from settings
@@ -77,23 +77,27 @@ export function getColors(colorType: Color) {
     }
 }
 
-// Retreive the settings for decorations outside math mode
+// Retrieve the settings for decorations outside math mode
 export function renderSymbolsOutsideMath() {
     return config.get<boolean>('renderSymbolsOutsideMath') || false;
 }
-// Retreive the settings for space rendering
+// Retrieve the settings for space rendering
 export function renderSpaces() {
     return config.get<boolean>('renderSpaces') || false;
 }
-// Retreive the settings for delimiter rendering
+// Retrieve the settings for delimiter rendering
 export function hideUnnecessaryDelimiters() {
     return config.get<boolean>('hideUnnecessaryDelimiters') || false;
 }
-// Retreive the settings for space rendering
+// Retrieve the settings for hiding leading and trailing quotes
+export function hideLeadingAndTrailingQuotes() {
+    return config.get<boolean>('hideLeadingAndTrailingQuotes') || false;
+}
+// Retrieve the settings for space rendering
 export function revealOffset() {
     return config.get<number>('revealOffset') || 0;
 }
-// Retreive the settings for custom symbols
+// Retrieve the settings for custom symbols
 export function customSymbols(): {
     name: string,
     symbol: string
@@ -116,7 +120,7 @@ export function customSymbols(): {
     }
     return user;
 }
-// Retreive blacklisted symbols
+// Retrieve blacklisted symbols
 export function blacklistedSymbols() {
     return config.get<string[]>('blacklist') || [];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@ interface Colors {
     group: string,
     operator: string,
     number: string,
+    string: string
 }
 
 // Default color themes
@@ -25,7 +26,8 @@ const darkTheme = {
     comparison: "#AE81FF",
     letter: "#A6E22E",
     group: "#66D9EF",
-    operator: "#FD971F"
+    operator: "#FD971F",
+    string: "#E6DB74"
 };
 // Light theme based on the Monokai theme
 const lightTheme = {
@@ -34,7 +36,8 @@ const lightTheme = {
     comparison: "#EE0000",
     letter: "#795E26",
     group: "#008000",
-    operator: "#0070C1"
+    operator: "#0070C1",
+    string: "#F9622E"
 };
 
 
@@ -51,6 +54,7 @@ function enumToColorName(colorEnum: Color): keyof Colors {
         case getWASM().Color.Letter: return "letter";
         case getWASM().Color.Set: return "group";
         case getWASM().Color.Number: return "number";
+        case getWASM().Color.String: return "letter";
     }
 }
 // Get colors from settings

--- a/typst-math-rust/src/interface.rs
+++ b/typst-math-rust/src/interface.rs
@@ -32,6 +32,7 @@ pub struct Options {
     pub render_outside_math: bool,
     pub render_spaces: bool,
     pub hide_unnecessary_delimiters: bool,
+    pub hide_leading_and_trailing_quotes: bool,
     pub blacklisted_symbols: Vec<String>,
     pub custom_symbols: HashMap<String, CustomSymbol>,
 }
@@ -43,6 +44,7 @@ impl Default for Options {
             render_outside_math: true,
             render_spaces: false,
             hide_unnecessary_delimiters: false,
+            hide_leading_and_trailing_quotes: false,
             blacklisted_symbols: vec![],
             custom_symbols: HashMap::new(),
         }

--- a/typst-math-rust/src/lib.rs
+++ b/typst-math-rust/src/lib.rs
@@ -43,6 +43,7 @@ pub fn parse_document(
     render_outside_math: bool,
     render_spaces: bool,
     hide_unnecessary_delimiters: bool,
+    hide_leading_and_trailing_quotes: bool,
     blacklisted_symbols: Vec<String>,
     custom_symbols: Vec<CustomSymbol>,
 ) -> Parsed {
@@ -121,6 +122,7 @@ pub fn parse_document(
         render_outside_math,
         render_spaces,
         hide_unnecessary_delimiters,
+        hide_leading_and_trailing_quotes,
         blacklisted_symbols,
         custom_symbols,
     };
@@ -173,6 +175,7 @@ mod tests {
             3,
             true,
             true,
+            false,
             false,
             vec![],
             vec![generate_custom_symbol(

--- a/typst-math-rust/src/main.rs
+++ b/typst-math-rust/src/main.rs
@@ -2,7 +2,18 @@ use typst_math_rust::parse_document;
 
 /// Usefull to test the library in pure rust
 fn main() {
-    let parsed = parse_document("$alpha^((2))$", -1, -1, 3, true, true, true, vec![], vec![]);
+    let parsed = parse_document(
+        "$alpha^((2))$",
+        -1,
+        -1,
+        3,
+        true,
+        true,
+        true,
+        true,
+        vec![],
+        vec![],
+    );
 
     println!("{:?}", parsed.decorations);
 }

--- a/typst-math-rust/src/parser/parser.rs
+++ b/typst-math-rust/src/parser/parser.rs
@@ -398,7 +398,7 @@ fn str_block(parser: &mut InnerParser) {
             format!("{}", parser.added_text_decoration),
             parser.offset,
         );
-    } else if !text.get().trim().is_empty() {
+    } else if parser.options.hide_leading_and_trailing_quotes && !text.get().trim().is_empty() {
         // If we are not in an attachment, just insert the text as is, this will trim the quotes
         parser.insert_result(
             parser.expr.range(),

--- a/typst-math-rust/src/parser/parser.rs
+++ b/typst-math-rust/src/parser/parser.rs
@@ -398,6 +398,16 @@ fn str_block(parser: &mut InnerParser) {
             format!("{}", parser.added_text_decoration),
             parser.offset,
         );
+    } else if !text.get().trim().is_empty() {
+        // If we are not in an attachment, just insert the text as is, this will trim the quotes
+        parser.insert_result(
+            parser.expr.range(),
+            format!("{}-str-{}", parser.uuid, text.get().to_string()),
+            text.get().to_string(),
+            Color::String,
+            format!("{}", parser.added_text_decoration),
+            parser.offset,
+        );
     }
 }
 

--- a/typst-math-rust/src/utils/symbols.rs
+++ b/typst-math-rust/src/utils/symbols.rs
@@ -55,6 +55,7 @@ pub enum Color {
     Letter,
     Set,
     Number,
+    String,
 }
 
 /// The list of general symbols.

--- a/typst-math-rust/tests/test.rs
+++ b/typst-math-rust/tests/test.rs
@@ -4,7 +4,18 @@ mod tests {
 
     #[test]
     fn basic_symbol() {
-        let parsed = parse_document("$alpha$", -1, -1, 3, true, true, false, vec![], vec![]);
+        let parsed = parse_document(
+            "$alpha$",
+            -1,
+            -1,
+            3,
+            true,
+            true,
+            false,
+            false,
+            vec![],
+            vec![],
+        );
         assert_eq!(parsed.decorations.len(), 1);
         assert_eq!(parsed.decorations[0].symbol, "α");
         assert_eq!(parsed.decorations[0].uuid, "alpha");
@@ -19,6 +30,7 @@ mod tests {
             3,
             true,
             true,
+            false,
             false,
             vec![],
             vec![],
@@ -38,16 +50,39 @@ mod tests {
             true,
             true,
             false,
+            false,
             vec![],
             vec![],
         );
         assert_eq!(parsed.decorations.len(), 2);
         assert_eq!(parsed.decorations[0].symbol, "α");
         assert_eq!(parsed.decorations[1].symbol, "α");
-        let parsed = parse_document("$x^alpha$", -1, -1, 3, true, true, false, vec![], vec![]);
+        let parsed = parse_document(
+            "$x^alpha$",
+            -1,
+            -1,
+            3,
+            true,
+            true,
+            false,
+            false,
+            vec![],
+            vec![],
+        );
         assert_eq!(parsed.decorations[0].positions[0].start, 2);
         assert_eq!(parsed.decorations[0].uuid, "top-alpha");
-        let parsed = parse_document("$x_alpha$", -1, -1, 3, true, true, false, vec![], vec![]);
+        let parsed = parse_document(
+            "$x_alpha$",
+            -1,
+            -1,
+            3,
+            true,
+            true,
+            false,
+            false,
+            vec![],
+            vec![],
+        );
         assert_eq!(parsed.decorations[0].uuid, "bottom-alpha");
 
         let parsed = parse_document(
@@ -57,6 +92,7 @@ mod tests {
             3,
             true,
             true,
+            false,
             false,
             vec![],
             vec![],
@@ -69,6 +105,7 @@ mod tests {
             0,
             true,
             true,
+            false,
             false,
             vec![],
             vec![],
@@ -86,6 +123,7 @@ mod tests {
             true,
             true,
             false,
+            false,
             vec![],
             vec![],
         );
@@ -98,6 +136,7 @@ mod tests {
             true,
             true,
             false,
+            false,
             vec![],
             vec![],
         );
@@ -105,7 +144,18 @@ mod tests {
     }
     #[test]
     fn test_functions() {
-        let parsed = parse_document("$arrow(x)$", -1, -1, 3, true, true, false, vec![], vec![]);
+        let parsed = parse_document(
+            "$arrow(x)$",
+            -1,
+            -1,
+            3,
+            true,
+            true,
+            false,
+            false,
+            vec![],
+            vec![],
+        );
         assert_eq!(parsed.decorations.len(), 2);
 
         // Check that not too many decorations are added
@@ -116,6 +166,7 @@ mod tests {
             3,
             true,
             true,
+            false,
             false,
             vec![],
             vec![],
@@ -129,6 +180,7 @@ mod tests {
             true,
             true,
             false,
+            false,
             vec![],
             vec![],
         );
@@ -141,6 +193,7 @@ mod tests {
             true,
             true,
             false,
+            false,
             vec![],
             vec![],
         );
@@ -148,7 +201,18 @@ mod tests {
     }
     #[test]
     fn test_field_access() {
-        let parsed = parse_document("$beta.alt$", -1, -1, 3, true, true, false, vec![], vec![]);
+        let parsed = parse_document(
+            "$beta.alt$",
+            -1,
+            -1,
+            3,
+            true,
+            true,
+            false,
+            false,
+            vec![],
+            vec![],
+        );
         assert_eq!(parsed.decorations.len(), 1);
         assert_eq!(parsed.decorations[0].symbol, "ϐ");
         assert_eq!(parsed.decorations[0].uuid, "beta.alt");
@@ -160,6 +224,7 @@ mod tests {
             true,
             true,
             false,
+            false,
             vec![],
             vec![],
         );
@@ -169,7 +234,18 @@ mod tests {
     }
     #[test]
     fn test_text() {
-        let parsed = parse_document("$x^a x_a$", -1, -1, 3, true, true, false, vec![], vec![]);
+        let parsed = parse_document(
+            "$x^a x_a$",
+            -1,
+            -1,
+            3,
+            true,
+            true,
+            false,
+            false,
+            vec![],
+            vec![],
+        );
         assert_eq!(parsed.decorations.len(), 2);
         assert_eq!(parsed.decorations[0].symbol, "a");
 
@@ -180,6 +256,7 @@ mod tests {
             3,
             true,
             true,
+            false,
             false,
             vec![],
             vec![],
@@ -197,6 +274,7 @@ mod tests {
             true,
             true,
             false,
+            false,
             vec![],
             vec![],
         );
@@ -213,11 +291,23 @@ mod tests {
             true,
             true,
             false,
+            false,
             vec![],
             vec![],
         );
         assert_eq!(parsed.decorations.len(), 3);
-        let parsed = parse_document("$x^(alpha)$", -1, -1, 3, true, true, false, vec![], vec![]);
+        let parsed = parse_document(
+            "$x^(alpha)$",
+            -1,
+            -1,
+            3,
+            true,
+            true,
+            false,
+            false,
+            vec![],
+            vec![],
+        );
         assert_eq!(parsed.decorations.len(), 2);
         let parsed = parse_document(
             "$x^(\"alpha\") x^(-\"alpha\") x^(-alpha)$",
@@ -226,6 +316,7 @@ mod tests {
             3,
             true,
             true,
+            false,
             false,
             vec![],
             vec![],
@@ -241,6 +332,7 @@ mod tests {
             3,
             true,
             true,
+            false,
             false,
             vec![],
             vec![],


### PR DESCRIPTION
Imitate other rules to make the final rendered string no leading or trailing quotes.